### PR TITLE
Minor tweaks to the Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,11 +11,5 @@ RUN sudo apt-get update && \
 RUN mkdir -p /home/gitpod/.julia && \
     cd /home/gitpod/.julia && \
     wget -c https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz && \
-    tar xvfz julia-1.0.1-linux-x86_64.tar.gz && \
-    sudo mv /home/gitpod/.julia/julia-1.0.1/bin/julia /usr/bin && \
-    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so /usr/lib && \
-    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so.1 /usr/lib && \
-    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so.1.0 /usr/lib && \
-    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/julia/* /usr/lib && \
-    sudo mv /home/gitpod/.julia/julia-1.0.1/include/* /usr/include && \
-    sudo mv /home/gitpod/.julia/julia-1.0.1/etc/julia /etc
+    tar xvfz julia-1.0.1-linux-x86_64.tar.gz
+ENV PATH="$PATH:/home/gitpod/.julia/julia-1.0.1/bin/"

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,13 +1,21 @@
 FROM gitpod/workspace-full
 
-USER root
+USER gitpod
 
-RUN sudo apt-get update && sudo apt-get install build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config --yes
-RUN mkdir -p /home/gitpod/.julia && cd /home/gitpod/.julia && wget -c https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz && tar xvfz julia-1.0.1-linux-x86_64.tar.gz
-RUN mv /home/gitpod/.julia/julia-1.0.1/bin/julia /usr/bin
-RUN mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so /usr/lib
-RUN mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so.1 /usr/lib
-RUN mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so.1.0 /usr/lib
-RUN mv /home/gitpod/.julia/julia-1.0.1/lib/julia/* /usr/lib
-RUN mv /home/gitpod/.julia/julia-1.0.1/include/* /usr/include
-RUN mv /home/gitpod/.julia/julia-1.0.1/etc/julia /etc
+# Install Julia dependencies
+RUN sudo apt-get update && \
+    sudo apt-get install build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config --yes && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# Install Julia
+RUN mkdir -p /home/gitpod/.julia && \
+    cd /home/gitpod/.julia && \
+    wget -c https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz && \
+    tar xvfz julia-1.0.1-linux-x86_64.tar.gz && \
+    sudo mv /home/gitpod/.julia/julia-1.0.1/bin/julia /usr/bin && \
+    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so /usr/lib && \
+    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so.1 /usr/lib && \
+    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/libjulia.so.1.0 /usr/lib && \
+    sudo mv /home/gitpod/.julia/julia-1.0.1/lib/julia/* /usr/lib && \
+    sudo mv /home/gitpod/.julia/julia-1.0.1/include/* /usr/include && \
+    sudo mv /home/gitpod/.julia/julia-1.0.1/etc/julia /etc


### PR DESCRIPTION
Many thanks for building a Julia set-up for Gitpod! 💯

It works really well, apart from a misplaced `sys.so` file, which I've fixed here.

I've also noticed a few minor things that could be improved in the Dockerfile:
- Switched to `USER gitpod` instead of `USER root`, which is a better practice
- Grouped many commands into fewer `RUN` instructions, to optimize Docker image size
- Removed `apt-get` cache, also for a lighter Docker image
- Installed Julia in `/home/gitpod/.julia` by adding the extracted archive directly to the `$PATH`, instead of trying to install every component into system paths, which is a bit more tedious and error-prone.

---

More details:

Essentially, every `RUN` instruction in a Dockerfile will create a new file system "layer", by persisting the file system immediately after the `RUN` instruction, and saving it into the Docker image history.

Unfortunately, this means that if you do:

```Dockerfile
RUN wget largefile.zip
RUN mv largefile.zip /tmp
RUN mv /tmp/largefile.zip $HOME
```

you will have three separate copies of `largefile.zip` in your Docker history. Even if you add `RUN rm $HOME/largefile.zip` afterwards, the layer history will be kept, and your resulting Docker image will be quite large.

Instead, it's more efficient to do something like this:

```Dockerfile
RUN wget largefile.zip && \
    mv largefile.zip /tmp && \
    mv /tmp/largefile.zip $HOME && \
    rm $HOME/largefile.zip
```

This will only persist the file system _after_ having executing the entire single `RUN` instruction, thus you will not keep `largefile.zip` in your Docker history, producing a much lighter Docker image.